### PR TITLE
refactor: abstract async title generation behind TitleService trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 mod app;
 mod data;
 mod fs;
+mod title_service;
 mod titles;
 mod ui;
 
 use app::{Action, App, Response};
+use title_service::{AnthropicTitleService, TitleService};
 use crossterm::{
     event::{self, Event, KeyCode, KeyModifiers},
     execute,
@@ -26,22 +28,9 @@ async fn main() -> anyhow::Result<()> {
 
     let (tx, rx) = mpsc::channel::<(String, String)>();
 
-    for proj in &projects {
-        for sess in &proj.sessions {
-            if sess.needs_title() {
-                let tx = tx.clone();
-                let uuid = sess.uuid.clone();
-                let msg = sess.first_message.clone().unwrap();
-                let cache = sess.title_cache_path();
-                tokio::spawn(async move {
-                    if let Some(title) = titles::generate_title(&msg).await {
-                        let _ = std::fs::write(&cache, &title);
-                        let _ = tx.send((uuid, title));
-                    }
-                });
-            }
-        }
-    }
+    let all_sessions: Vec<&data::Session> =
+        projects.iter().flat_map(|p| p.sessions.iter()).collect();
+    AnthropicTitleService.start(&all_sessions, tx);
 
     let app = App::new(projects);
     let outcome = run_tui(app, rx)?;

--- a/src/title_service.rs
+++ b/src/title_service.rs
@@ -1,0 +1,45 @@
+use std::sync::mpsc;
+
+use crate::data::Session;
+
+/// Generates and delivers session titles asynchronously.
+///
+/// Implementations spawn background work and send `(uuid, title)` pairs
+/// over `tx` as results arrive. The caller drives the TUI loop; titles
+/// appear incrementally as the channel drains.
+pub trait TitleService {
+    fn start(&self, sessions: &[&Session], tx: mpsc::Sender<(String, String)>);
+}
+
+/// Production implementation: calls the Anthropic API and caches results.
+pub struct AnthropicTitleService;
+
+impl TitleService for AnthropicTitleService {
+    fn start(&self, sessions: &[&Session], tx: mpsc::Sender<(String, String)>) {
+        for sess in sessions {
+            if !sess.needs_title() {
+                continue;
+            }
+            let tx = tx.clone();
+            let uuid = sess.uuid.clone();
+            let msg = sess.first_message.clone().unwrap();
+            let cache = sess.title_cache_path();
+            tokio::spawn(async move {
+                if let Some(title) = crate::titles::generate_title(&msg).await {
+                    let _ = std::fs::write(&cache, &title);
+                    let _ = tx.send((uuid, title));
+                }
+            });
+        }
+    }
+}
+
+/// No-op implementation for tests — sends nothing, spawns nothing.
+#[cfg(test)]
+#[allow(dead_code)]
+pub struct NoopTitleService;
+
+#[cfg(test)]
+impl TitleService for NoopTitleService {
+    fn start(&self, _sessions: &[&Session], _tx: mpsc::Sender<(String, String)>) {}
+}


### PR DESCRIPTION
Closes #5

## Summary
- Add `src/title_service.rs` with `TitleService` trait: `start(&[&Session], mpsc::Sender)` owns the full lifecycle (spawn, API call, cache write, send)
- `AnthropicTitleService` — production impl wrapping `titles::generate_title`
- `NoopTitleService` — test stub that sends nothing and spawns nothing, enabling TUI loop tests without network access
- `main()` reduced to collecting sessions and calling `AnthropicTitleService.start()` — inline `tokio::spawn` loop removed

## Test plan
- [x] 29 existing tests still pass, clippy clean
- [ ] Manual smoke test: titles still appear incrementally in the TUI after resuming sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)