### PR TITLE
refactor: surface parse failures in data loading pipeline

### DIFF
--- a/ARCHITECTURE_TODOS.md
+++ b/ARCHITECTURE_TODOS.md
@@ -2,6 +2,7 @@
 
 Candidates identified during the `/improve-codebase-architecture` session (2026-04-08).
 Candidates 1 (Session Lifecycle) and 2 (SessionStore) are done — see PRs #25 and #27.
+Candidate 3 (Data Loading Pipeline) is done — see PR #28.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use arboard::Clipboard;
 use ratatui::widgets::ListState;
 
-use crate::data::{Project, Session};
+use crate::data::{Project, Session, SessionTitle};
 use crate::session_store::DynStore;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -142,7 +142,7 @@ impl App {
                     for p in &mut self.projects {
                         for s in &mut p.sessions {
                             if s.uuid == uuid {
-                                s.title = Some(title);
+                                s.title = SessionTitle::Loaded(title);
                                 return Ok(Response::Continue);
                             }
                         }
@@ -152,10 +152,10 @@ impl App {
             }
             Action::StartEditTitle => {
                 if self.active_pane == Pane::Sessions && self.current_session().is_some() {
-                    let prefill = self
-                        .current_session()
-                        .and_then(|s| s.title.clone())
-                        .unwrap_or_default();
+                    let prefill = match self.current_session().map(|s| &s.title) {
+                        Some(SessionTitle::Loaded(t)) => t.clone(),
+                        _ => String::new(),
+                    };
                     self.editing_title = Some(prefill);
                 }
                 Ok(Response::Continue)
@@ -184,7 +184,7 @@ impl App {
                         let si = self.selection.session;
                         if let Some(sess) = self.projects.get_mut(pi).and_then(|p| p.sessions.get_mut(si)) {
                             self.store.save_title(sess, &trimmed)?;
-                            sess.title = Some(trimmed);
+                            sess.title = SessionTitle::Loaded(trimmed);
                             self.status = "Title updated.".into();
                         }
                     }
@@ -327,7 +327,7 @@ mod tests {
     use std::time::SystemTime;
 
     use super::*;
-    use crate::data::Session;
+    use crate::data::{Session, SessionTitle};
     use crate::session_store::NullSessionStore;
 
     fn make_session(uuid: &str) -> Session {
@@ -337,9 +337,10 @@ mod tests {
             cwd: PathBuf::from("/tmp"),
             git_branch: None,
             first_message: Some("hello".into()),
-            title: None,
+            title: SessionTitle::Absent,
             last_modified: SystemTime::UNIX_EPOCH,
             size_bytes: 0,
+            parse_error: None,
         }
     }
 
@@ -432,7 +433,7 @@ mod tests {
     #[test]
     fn start_edit_title_prefills_existing_title() {
         let mut app = make_app(&[2]);
-        app.projects[0].sessions[0].title = Some("Existing Title".into());
+        app.projects[0].sessions[0].title = SessionTitle::Loaded("Existing Title".into());
         app.dispatch(Action::SwitchPane).unwrap();
         app.dispatch(Action::StartEditTitle).unwrap();
         assert_eq!(app.editing_title(), Some("Existing Title"));
@@ -462,7 +463,7 @@ mod tests {
         app.dispatch(Action::EditTitleChar('H')).unwrap();
         app.dispatch(Action::CancelEditTitle).unwrap();
         assert_eq!(app.editing_title(), None);
-        assert_eq!(app.current_session().unwrap().title, None); // title unchanged
+        assert_eq!(app.current_session().unwrap().title, SessionTitle::Absent); // title unchanged
     }
 
     #[test]
@@ -475,7 +476,7 @@ mod tests {
         }
         app.dispatch(Action::ConfirmEditTitle).unwrap();
         assert_eq!(app.editing_title(), None);
-        assert_eq!(app.current_session().unwrap().title.as_deref(), Some("New Title"));
+        assert_eq!(app.current_session().unwrap().title, SessionTitle::Loaded("New Title".into()));
     }
 
     #[test]
@@ -486,7 +487,7 @@ mod tests {
         app.dispatch(Action::EditTitleChar(' ')).unwrap();
         app.dispatch(Action::ConfirmEditTitle).unwrap();
         assert_eq!(app.editing_title(), None);
-        assert_eq!(app.current_session().unwrap().title, None); // not updated
+        assert_eq!(app.current_session().unwrap().title, SessionTitle::Absent); // not updated
     }
 
     #[test]
@@ -512,7 +513,7 @@ mod tests {
         app.dispatch(Action::TitleUpdate { uuid: uuid.clone(), title: "Async Title".into() }).unwrap();
         // Edit buffer is intact, session.title was NOT overwritten
         assert_eq!(app.editing_title(), Some("M"));
-        assert_eq!(app.current_session().unwrap().title, None);
+        assert_eq!(app.current_session().unwrap().title, SessionTitle::Absent);
     }
 
     #[test]
@@ -525,6 +526,6 @@ mod tests {
         // Title arrives for session 1 (not being edited)
         app.dispatch(Action::TitleUpdate { uuid: other_uuid.clone(), title: "Other Title".into() }).unwrap();
         // Session 1 title was updated normally
-        assert_eq!(app.projects[0].sessions[1].title.as_deref(), Some("Other Title"));
+        assert_eq!(app.projects[0].sessions[1].title, SessionTitle::Loaded("Other Title".into()));
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -45,6 +45,22 @@ struct ContentBlock {
     text: Option<String>,
 }
 
+/// The state of a session's cached title.
+///
+/// Distinguishes three states that `Option<String>` cannot: a title that was
+/// never generated, one that loaded successfully, and one whose cache file
+/// exists but could not be read. The title service uses this to avoid
+/// attempting to save a title to a location that has already proven unwritable.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionTitle {
+    /// No `.title` cache file exists — normal state for an untitled session.
+    Absent,
+    /// `.title` file was read successfully.
+    Loaded(String),
+    /// `.title` file exists but could not be read (permissions, corruption, etc.).
+    Unreadable,
+}
+
 #[derive(Debug, Clone)]
 pub struct Session {
     pub uuid: String,
@@ -52,9 +68,12 @@ pub struct Session {
     pub cwd: PathBuf,
     pub git_branch: Option<String>,
     pub first_message: Option<String>,
-    pub title: Option<String>,
+    pub title: SessionTitle,
     pub last_modified: SystemTime,
     pub size_bytes: u64,
+    /// Set when the JSONL header could not be read (I/O error).
+    /// `None` means the session loaded cleanly.
+    pub parse_error: Option<String>,
 }
 
 impl Session {
@@ -63,7 +82,11 @@ impl Session {
     }
 
     pub fn needs_title(&self) -> bool {
-        self.title.is_none() && self.first_message.is_some()
+        self.title == SessionTitle::Absent && self.first_message.is_some()
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        self.parse_error.is_some()
     }
 }
 
@@ -141,17 +164,27 @@ fn load_sessions(dir: &Path) -> anyhow::Result<Vec<Session>> {
         let last_modified = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
         let size_bytes = meta.len();
 
-        let (cwd, git_branch, first_message) = parse_header(&path).unwrap_or_default();
+        let (cwd, git_branch, first_message, parse_error) = match parse_header(&path) {
+            Ok((cwd, branch, msg)) => (cwd, branch, msg, None),
+            Err(e) => (None, None, None, Some(e.to_string())),
+        };
 
         let title = {
             let cp = path.with_extension("title");
             if cp.exists() {
-                std::fs::read_to_string(&cp)
-                    .ok()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
+                match std::fs::read_to_string(&cp) {
+                    Ok(s) => {
+                        let trimmed = s.trim().to_string();
+                        if trimmed.is_empty() {
+                            SessionTitle::Absent
+                        } else {
+                            SessionTitle::Loaded(trimmed)
+                        }
+                    }
+                    Err(_) => SessionTitle::Unreadable,
+                }
             } else {
-                None
+                SessionTitle::Absent
             }
         };
 
@@ -164,6 +197,7 @@ fn load_sessions(dir: &Path) -> anyhow::Result<Vec<Session>> {
             title,
             last_modified,
             size_bytes,
+            parse_error,
         });
     }
 
@@ -392,5 +426,58 @@ mod tests {
         );
         let (_, _, msg) = parse(&line);
         assert_eq!(msg.as_deref(), Some("foo"));
+    }
+
+    // ── SessionTitle / needs_title / is_degraded ──────────────────────────────
+
+    fn make_session(title: SessionTitle, first_message: Option<&str>, parse_error: Option<&str>) -> Session {
+        Session {
+            uuid: "test-uuid".into(),
+            jsonl_path: std::path::PathBuf::from("/tmp/test.jsonl"),
+            cwd: std::path::PathBuf::from("/tmp"),
+            git_branch: None,
+            first_message: first_message.map(String::from),
+            title,
+            last_modified: std::time::SystemTime::UNIX_EPOCH,
+            size_bytes: 0,
+            parse_error: parse_error.map(String::from),
+        }
+    }
+
+    #[test]
+    fn needs_title_true_when_absent_and_has_message() {
+        let s = make_session(SessionTitle::Absent, Some("hello"), None);
+        assert!(s.needs_title());
+    }
+
+    #[test]
+    fn needs_title_false_when_title_loaded() {
+        let s = make_session(SessionTitle::Loaded("My Title".into()), Some("hello"), None);
+        assert!(!s.needs_title());
+    }
+
+    #[test]
+    fn needs_title_false_when_no_first_message() {
+        let s = make_session(SessionTitle::Absent, None, None);
+        assert!(!s.needs_title());
+    }
+
+    #[test]
+    fn needs_title_false_when_title_unreadable() {
+        // Unreadable means the cache file exists but is corrupt — don't retry.
+        let s = make_session(SessionTitle::Unreadable, Some("hello"), None);
+        assert!(!s.needs_title());
+    }
+
+    #[test]
+    fn is_degraded_false_for_clean_session() {
+        let s = make_session(SessionTitle::Absent, Some("hello"), None);
+        assert!(!s.is_degraded());
+    }
+
+    #[test]
+    fn is_degraded_true_when_parse_error_set() {
+        let s = make_session(SessionTitle::Absent, None, Some("failed to open file: permission denied"));
+        assert!(s.is_degraded());
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use crate::app::{App, Pane};
-use crate::data::Session;
+use crate::data::{Session, SessionTitle};
 use ratatui::{
     prelude::*,
     widgets::*,
@@ -10,7 +10,7 @@ use ratatui::{
 // ── Session display formatting ────────────────────────────────────────────────
 
 pub fn session_title(s: &Session) -> String {
-    if let Some(t) = &s.title {
+    if let SessionTitle::Loaded(t) = &s.title {
         return t.clone();
     }
     if let Some(msg) = &s.first_message {
@@ -162,7 +162,11 @@ fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
             } else {
                 Line::from(Span::raw(format!(" {}", session_title(s))))
             };
-            let branch = s.git_branch.as_deref().unwrap_or("?");
+            let branch = if s.is_degraded() {
+                "[parse error]"
+            } else {
+                s.git_branch.as_deref().unwrap_or("?")
+            };
             let meta = format!(
                 "   {} · {} · {}",
                 branch,
@@ -280,9 +284,13 @@ mod tests {
             cwd: PathBuf::from("/tmp"),
             git_branch: None,
             first_message: first_message.map(String::from),
-            title: title.map(String::from),
+            title: match title {
+                Some(t) => SessionTitle::Loaded(t.to_string()),
+                None => SessionTitle::Absent,
+            },
             last_modified: SystemTime::UNIX_EPOCH,
             size_bytes,
+            parse_error: None,
         }
     }
 


### PR DESCRIPTION
Closes #28

## Summary
- Introduces `SessionTitle` enum (`Absent` / `Loaded(String)` / `Unreadable`) replacing `Option<String>` — distinguishes "never generated" from "cache file exists but unreadable", so the title service skips retries on unreadable files
- Adds `parse_error: Option<String>` to `Session` — set when the JSONL header fails to open (I/O error); `None` means clean load
- `is_degraded()` convenience method on `Session`; renderer shows `[parse error]` in the branch slot for degraded sessions
- `load_sessions` now captures `parse_header` errors explicitly instead of `unwrap_or_default()`
- 6 new tests in `data.rs` covering all `SessionTitle` variants and `is_degraded()`

## Test plan
- [x] `cargo test` — all 47 tests pass
- [x] Launch the app against `~/.claude/projects` and verify healthy sessions render normally
- [x] Verify a session with a generated title still shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)