### PR TITLE
refactor: consolidate modal routing behind App::modal() accessor

### DIFF
--- a/ARCHITECTURE_TODOS.md
+++ b/ARCHITECTURE_TODOS.md
@@ -2,6 +2,9 @@
 
 Candidates identified during the `/improve-codebase-architecture` session (2026-04-08).
 Candidates 1 (Session Lifecycle) and 2 (SessionStore) are done — see PRs #25 and #27.
+Candidate 3 (Data Loading Pipeline) is done — see PR #28.
+Candidate 4 (Title Service) is done — see PR #30.
+Candidate 5 (TUI Event Loop) is done — see PR #32.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,19 @@ impl Pane {
     }
 }
 
+/// The active input mode of the application.
+///
+/// `tui_loop` dispatches key events based solely on this value — no knowledge
+/// of individual `App` fields required. Adding a new modal means adding a
+/// variant here and a routing arm in `tui_loop`, with the compiler enforcing
+/// that both are handled.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Modal {
+    None,
+    EditTitle,
+    ConfirmDelete,
+}
+
 pub enum Action {
     NavUp,
     NavDown,
@@ -202,6 +215,17 @@ impl App {
 
     pub fn active_pane(&self) -> Pane {
         self.active_pane
+    }
+
+    /// The active input mode. `tui_loop` routes key events based solely on this.
+    pub fn modal(&self) -> Modal {
+        if self.editing_title.is_some() {
+            Modal::EditTitle
+        } else if self.delete_pending {
+            Modal::ConfirmDelete
+        } else {
+            Modal::None
+        }
     }
 
     pub fn delete_pending(&self) -> bool {
@@ -526,5 +550,45 @@ mod tests {
         app.dispatch(Action::TitleUpdate { uuid: other_uuid.clone(), title: "Other Title".into() }).unwrap();
         // Session 1 title was updated normally
         assert_eq!(app.projects[0].sessions[1].title.as_deref(), Some("Other Title"));
+    }
+
+    // ── modal() ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn modal_is_none_by_default() {
+        let app = make_app(&[1]);
+        assert_eq!(app.modal(), Modal::None);
+    }
+
+    #[test]
+    fn modal_is_edit_title_while_editing() {
+        let mut app = make_app(&[1]);
+        app.dispatch(Action::SwitchPane).unwrap();
+        app.dispatch(Action::StartEditTitle).unwrap();
+        assert_eq!(app.modal(), Modal::EditTitle);
+        // cancelling returns to None
+        app.dispatch(Action::CancelEditTitle).unwrap();
+        assert_eq!(app.modal(), Modal::None);
+    }
+
+    #[test]
+    fn modal_is_confirm_delete_while_pending() {
+        let mut app = make_app(&[1]);
+        app.dispatch(Action::SwitchPane).unwrap();
+        app.dispatch(Action::RequestDelete).unwrap();
+        assert_eq!(app.modal(), Modal::ConfirmDelete);
+        // cancelling returns to None
+        app.dispatch(Action::CancelDelete).unwrap();
+        assert_eq!(app.modal(), Modal::None);
+    }
+
+    #[test]
+    fn modal_is_none_after_delete_confirmed() {
+        let mut app = make_app(&[2]);
+        app.dispatch(Action::SwitchPane).unwrap();
+        app.dispatch(Action::RequestDelete).unwrap();
+        assert_eq!(app.modal(), Modal::ConfirmDelete);
+        app.dispatch(Action::ConfirmDelete).unwrap();
+        assert_eq!(app.modal(), Modal::None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod ui;
 
 use std::sync::Arc;
 
-use app::{Action, App, Response};
+use app::{Action, App, Modal, Response};
 use session_store::FsSessionStore;
 use title_service::{AnthropicTitleService, TitleService};
 use crossterm::{
@@ -115,24 +115,20 @@ where
             continue;
         }
 
-        let action = if app.editing_title().is_some() {
-            // Title edit mode: intercept all keys for the input buffer.
-            match key.code {
+        let action = match app.modal() {
+            Modal::EditTitle => match key.code {
                 KeyCode::Esc => Action::CancelEditTitle,
                 KeyCode::Enter => Action::ConfirmEditTitle,
                 KeyCode::Backspace => Action::EditTitleBackspace,
                 KeyCode::Char(c) => Action::EditTitleChar(c),
                 _ => continue,
-            }
-        } else if app.delete_pending() {
-            // Confirmation overlay: only these keys are meaningful.
-            match key.code {
+            },
+            Modal::ConfirmDelete => match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => Action::ConfirmDelete,
                 KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => Action::CancelDelete,
                 _ => continue,
-            }
-        } else {
-            match key.code {
+            },
+            Modal::None => match key.code {
                 KeyCode::Char('q') => Action::Quit,
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::Quit,
                 KeyCode::Up | KeyCode::Char('k') => Action::NavUp,
@@ -147,7 +143,7 @@ where
                 KeyCode::Char('e') => Action::StartEditTitle,
                 KeyCode::Char('y') => Action::CopyMessage,
                 _ => continue,
-            }
+            },
         };
 
         match app.dispatch(action)? {


### PR DESCRIPTION
Closes #32

## Summary
- Adds `Modal` enum (`None | EditTitle | ConfirmDelete`) to `app.rs`
- Adds `App::modal() -> Modal` accessor — single call answers "what mode is the app in?" with no field inspection at call sites
- Replaces `if app.editing_title().is_some() ... else if app.delete_pending()` in `tui_loop` with `match app.modal()` — `main.rs` no longer knows about `editing_title` or `delete_pending` fields
- 4 new tests verify the `modal()` contract via `dispatch()` without a terminal

## Test plan
- [x] `cargo test` — all 45 tests pass
- [x] Launch the app and verify title editing and delete confirm both still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)