### PR TITLE
refactor: extract Theme struct to replace hard-coded colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "catppuccin"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be1bbab195d00e745c1788bed24ad8c30678c735d3d9e5bd0f87f9789433971"
+dependencies = [
+ "itertools",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "ratatui-core",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +201,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arboard",
+ "catppuccin",
  "crossterm",
  "dirs",
  "ratatui",
@@ -192,6 +209,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -2240,6 +2258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2667,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3280,6 +3346,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ reqwest = { version = "0.13", features = ["json"] }
 dirs = "6"
 anyhow = "1"
 arboard = "3"
+catppuccin = { version = "2.7.0", features = ["ratatui"] }
+toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A terminal UI for browsing and resuming [Claude Code](https://claude.ai/code) se
 - Full first message preview when navigating sessions
 - Resume any session — `ccm` `cd`s to the original project directory and hands off to `claude --resume`
 - Delete old sessions with confirmation
+- Themeable: built-in named themes and per-color config file overrides
 
 ## Installation
 
@@ -26,7 +27,7 @@ cargo install --path .
 ## Usage
 
 ```bash
-ccm
+ccm [--theme <name>]
 ```
 
 ### Keys
@@ -38,6 +39,27 @@ ccm
 | `Enter` | Resume session / switch to sessions pane |
 | `d` | Delete session (with confirmation) |
 | `q` / `Ctrl+C` | Quit |
+
+### Theming
+
+Pass `--theme <name>` on the command line or set `theme` in `~/.config/ccm/config.toml`.
+
+Available themes: `gruvbox-dark` (default), `catppuccin-mocha`, `catppuccin-macchiato`, `catppuccin-frappe`, `catppuccin-latte`
+
+Individual colors can be overridden in the config file regardless of which theme is active:
+
+```toml
+# ~/.config/ccm/config.toml
+theme = "catppuccin-mocha"
+
+[colors]
+active = "#ff9900"   # active pane border, edit cursor
+danger = "#ff0000"   # delete confirmation
+```
+
+Available color keys: `active`, `inactive`, `meta`, `preview_text`, `status_msg`, `hint`, `danger`
+
+Precedence: `--theme` flag > config `theme` > `[colors]` overrides > default (`gruvbox-dark`)
 
 ### AI Titles
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,5 +33,5 @@ impl Config {
 }
 
 fn config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("ccm").join("config.toml"))
+    dirs::home_dir().map(|h| h.join(".config").join("ccm").join("config.toml"))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,37 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Config {
+    /// Named theme (e.g. "gruvbox-dark", "catppuccin-mocha").
+    pub theme: Option<String>,
+    /// Per-color overrides applied on top of the selected theme.
+    #[serde(default)]
+    pub colors: ColorOverrides,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ColorOverrides {
+    pub active:       Option<String>,
+    pub inactive:     Option<String>,
+    pub meta:         Option<String>,
+    pub preview_text: Option<String>,
+    pub status_msg:   Option<String>,
+    pub hint:         Option<String>,
+    pub danger:       Option<String>,
+}
+
+impl Config {
+    /// Load from `~/.config/ccm/config.toml`, silently returning defaults on
+    /// any error (missing file, parse failure, etc.).
+    pub fn load() -> Self {
+        config_path()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+}
+
+fn config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("ccm").join("config.toml"))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod config;
 mod data;
 mod session_store;
 mod title_service;
@@ -26,6 +27,10 @@ enum Outcome {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let cli_theme = parse_theme_flag();
+    let config = config::Config::load();
+    let theme = resolve_theme(cli_theme.as_deref(), &config);
+
     let store: session_store::DynStore = Arc::new(FsSessionStore::new()?);
     let projects = store.load()?;
 
@@ -34,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     let title_handle = AnthropicTitleService { store: Arc::clone(&store) }.start(&all_sessions);
 
     let app = App::new(projects, store);
-    let outcome = run_tui(app, title_handle)?;
+    let outcome = run_tui(app, title_handle, theme)?;
 
     if let Outcome::Resume { cwd, uuid } = outcome {
         if cwd.as_os_str().is_empty() || !cwd.exists() {
@@ -69,14 +74,33 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_tui(mut app: App, handle: TitleHandle) -> anyhow::Result<Outcome> {
+/// Returns the value of `--theme <name>` if present on the command line.
+fn parse_theme_flag() -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+    args.windows(2)
+        .find(|w| w[0] == "--theme")
+        .map(|w| w[1].clone())
+}
+
+/// Resolve the final theme: CLI flag > config file `theme` > default.
+/// Config `[colors]` overrides are applied on top of whatever theme is selected.
+fn resolve_theme(cli_theme: Option<&str>, config: &config::Config) -> ui::Theme {
+    let name = cli_theme.or(config.theme.as_deref());
+    let mut theme = name
+        .and_then(ui::Theme::from_name)
+        .unwrap_or_else(ui::Theme::gruvbox_dark);
+    theme.apply_overrides(&config.colors);
+    theme
+}
+
+fn run_tui(mut app: App, handle: TitleHandle, theme: ui::Theme) -> anyhow::Result<Outcome> {
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let outcome = tui_loop(&mut terminal, &mut app, &handle.rx);
+    let outcome = tui_loop(&mut terminal, &mut app, &handle.rx, theme);
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
@@ -90,11 +114,11 @@ fn tui_loop<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
     rx: &std::sync::mpsc::Receiver<(String, String)>,
+    theme: ui::Theme,
 ) -> anyhow::Result<Outcome>
 where
     B::Error: Send + Sync + 'static,
 {
-    let theme = ui::Theme::gruvbox_dark();
 
     loop {
         while let Ok((uuid, title)) = rx.try_recv() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,12 +94,14 @@ fn tui_loop<B: Backend>(
 where
     B::Error: Send + Sync + 'static,
 {
+    let theme = ui::Theme::gruvbox_dark();
+
     loop {
         while let Ok((uuid, title)) = rx.try_recv() {
             app.dispatch(Action::TitleUpdate { uuid, title })?;
         }
 
-        terminal.draw(|f| ui::render(f, app))?;
+        terminal.draw(|f| ui::render(f, app, &theme))?;
 
         if !event::poll(Duration::from_millis(100))? {
             continue;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -38,6 +38,101 @@ impl Theme {
             danger:       Color::Red,
         }
     }
+
+    pub fn catppuccin_mocha() -> Self {
+        let c = &catppuccin::PALETTE.mocha.colors;
+        Self {
+            active:       c.yellow.into(),
+            inactive:     c.surface1.into(),
+            meta:         c.subtext0.into(),
+            preview_text: c.overlay2.into(),
+            status_msg:   c.peach.into(),
+            hint:         c.overlay0.into(),
+            danger:       c.red.into(),
+        }
+    }
+
+    pub fn catppuccin_macchiato() -> Self {
+        let c = &catppuccin::PALETTE.macchiato.colors;
+        Self {
+            active:       c.yellow.into(),
+            inactive:     c.surface1.into(),
+            meta:         c.subtext0.into(),
+            preview_text: c.overlay2.into(),
+            status_msg:   c.peach.into(),
+            hint:         c.overlay0.into(),
+            danger:       c.red.into(),
+        }
+    }
+
+    pub fn catppuccin_frappe() -> Self {
+        let c = &catppuccin::PALETTE.frappe.colors;
+        Self {
+            active:       c.yellow.into(),
+            inactive:     c.surface1.into(),
+            meta:         c.subtext0.into(),
+            preview_text: c.overlay2.into(),
+            status_msg:   c.peach.into(),
+            hint:         c.overlay0.into(),
+            danger:       c.red.into(),
+        }
+    }
+
+    pub fn catppuccin_latte() -> Self {
+        let c = &catppuccin::PALETTE.latte.colors;
+        Self {
+            active:       c.yellow.into(),
+            inactive:     c.surface1.into(),
+            meta:         c.subtext0.into(),
+            preview_text: c.overlay2.into(),
+            status_msg:   c.peach.into(),
+            hint:         c.overlay0.into(),
+            danger:       c.red.into(),
+        }
+    }
+
+    /// Look up a theme by name. Returns `None` for unknown names.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "gruvbox-dark"          => Some(Self::gruvbox_dark()),
+            "catppuccin-mocha"      => Some(Self::catppuccin_mocha()),
+            "catppuccin-macchiato"  => Some(Self::catppuccin_macchiato()),
+            "catppuccin-frappe"     => Some(Self::catppuccin_frappe()),
+            "catppuccin-latte"      => Some(Self::catppuccin_latte()),
+            _                       => None,
+        }
+    }
+
+    /// Apply per-color overrides from the config file on top of this theme.
+    pub fn apply_overrides(&mut self, overrides: &crate::config::ColorOverrides) {
+        macro_rules! apply {
+            ($field:ident) => {
+                if let Some(ref hex) = overrides.$field {
+                    if let Some(color) = parse_hex_color(hex) {
+                        self.$field = color;
+                    }
+                }
+            };
+        }
+        apply!(active);
+        apply!(inactive);
+        apply!(meta);
+        apply!(preview_text);
+        apply!(status_msg);
+        apply!(hint);
+        apply!(danger);
+    }
+}
+
+fn parse_hex_color(hex: &str) -> Option<Color> {
+    let hex = hex.trim_start_matches('#');
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some(Color::Rgb(r, g, b))
 }
 
 // ── Session display formatting ────────────────────────────────────────────────

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,6 +7,39 @@ use ratatui::{
     widgets::*,
 };
 
+// ── Theme ─────────────────────────────────────────────────────────────────────
+
+pub struct Theme {
+    /// Active pane border and edit-mode cursor/text.
+    pub active: Color,
+    /// Inactive pane border and selection highlight background.
+    pub inactive: Color,
+    /// Secondary / meta text (counts, branch, age, size).
+    pub meta: Color,
+    /// Preview pane body text.
+    pub preview_text: Color,
+    /// Transient app status messages (e.g. "Copied!").
+    pub status_msg: Color,
+    /// Keyboard hint bar text.
+    pub hint: Color,
+    /// Danger / destructive action (delete confirm).
+    pub danger: Color,
+}
+
+impl Theme {
+    pub fn gruvbox_dark() -> Self {
+        Self {
+            active:       Color::Rgb(250, 189, 47),
+            inactive:     Color::Rgb(80, 73, 69),
+            meta:         Color::Rgb(168, 153, 132),
+            preview_text: Color::Gray,
+            status_msg:   Color::Yellow,
+            hint:         Color::DarkGray,
+            danger:       Color::Red,
+        }
+    }
+}
+
 // ── Session display formatting ────────────────────────────────────────────────
 
 pub fn session_title(s: &Session) -> String {
@@ -72,7 +105,7 @@ pub fn session_size(s: &Session) -> String {
     }
 }
 
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &App, theme: &Theme) {
     let area = frame.area();
 
     let chunks = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);
@@ -87,22 +120,22 @@ pub fn render(frame: &mut Frame, app: &App) {
     let mut proj_state = app.projects_list_state();
     let mut sess_state = app.sessions_list_state();
 
-    render_projects(frame, app, panes[0], &mut proj_state);
-    render_sessions(frame, app, right[0], &mut sess_state);
-    render_preview(frame, app, right[1]);
-    render_status(frame, app, chunks[1]);
+    render_projects(frame, app, panes[0], &mut proj_state, theme);
+    render_sessions(frame, app, right[0], &mut sess_state, theme);
+    render_preview(frame, app, right[1], theme);
+    render_status(frame, app, chunks[1], theme);
 
     if app.delete_pending() {
-        render_confirm(frame, area);
+        render_confirm(frame, area, theme);
     }
 }
 
-fn render_projects(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui::widgets::ListState) {
+fn render_projects(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui::widgets::ListState, theme: &Theme) {
     let active = app.active_pane() == Pane::Projects;
     let border_style = if active {
-        Style::default().fg(Color::Rgb(250, 189, 47))
+        Style::default().fg(theme.active)
     } else {
-        Style::default().fg(Color::Rgb(80, 73, 69))
+        Style::default().fg(theme.inactive)
     };
 
     let items: Vec<ListItem> = app
@@ -114,7 +147,7 @@ fn render_projects(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
                 Span::raw(format!(" {} ", p.label)),
                 Span::styled(
                     format!("[{count}]"),
-                    Style::default().fg(Color::Rgb(168, 153, 132)),
+                    Style::default().fg(theme.meta),
                 ),
             ]))
         })
@@ -128,8 +161,8 @@ fn render_projects(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
         )
         .highlight_style(
             Style::default()
-                .bg(Color::Rgb(80, 73, 69))
-                .fg(Color::Rgb(250, 189, 47))
+                .bg(theme.inactive)
+                .fg(theme.active)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("> ");
@@ -137,12 +170,12 @@ fn render_projects(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
     frame.render_stateful_widget(list, area, state);
 }
 
-fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui::widgets::ListState) {
+fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui::widgets::ListState, theme: &Theme) {
     let active = app.active_pane() == Pane::Sessions;
     let border_style = if active {
-        Style::default().fg(Color::Rgb(250, 189, 47))
+        Style::default().fg(theme.active)
     } else {
-        Style::default().fg(Color::Rgb(80, 73, 69))
+        Style::default().fg(theme.inactive)
     };
 
     let selected_idx = app.sessions_list_state().selected();
@@ -156,8 +189,8 @@ fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
             let title_line = if let Some(buf) = editing_buf && selected_idx == Some(i) {
                 Line::from(vec![
                     Span::raw(" "),
-                    Span::styled(buf, Style::default().fg(Color::Rgb(250, 189, 47))),
-                    Span::styled("█", Style::default().fg(Color::Rgb(250, 189, 47))),
+                    Span::styled(buf, Style::default().fg(theme.active)),
+                    Span::styled("█", Style::default().fg(theme.active)),
                 ])
             } else {
                 Line::from(Span::raw(format!(" {}", session_title(s))))
@@ -175,7 +208,7 @@ fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
             );
             ListItem::new(Text::from(vec![
                 title_line,
-                Line::from(Span::styled(meta, Style::default().fg(Color::Rgb(168, 153, 132)))),
+                Line::from(Span::styled(meta, Style::default().fg(theme.meta))),
             ]))
         })
         .collect();
@@ -193,8 +226,8 @@ fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
         )
         .highlight_style(
             Style::default()
-                .bg(Color::Rgb(80, 73, 69))
-                .fg(Color::Rgb(250, 189, 47))
+                .bg(theme.inactive)
+                .fg(theme.active)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("> ");
@@ -202,16 +235,16 @@ fn render_sessions(frame: &mut Frame, app: &App, area: Rect, state: &mut ratatui
     frame.render_stateful_widget(list, area, state);
 }
 
-fn render_preview(frame: &mut Frame, app: &App, area: Rect) {
+fn render_preview(frame: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     let text = app
         .current_session()
         .and_then(|s| s.first_message.as_deref())
         .unwrap_or("");
 
     let border_style = if app.active_pane() == Pane::Sessions {
-        Style::default().fg(Color::Rgb(250, 189, 47))
+        Style::default().fg(theme.active)
     } else {
-        Style::default().fg(Color::Rgb(80, 73, 69))
+        Style::default().fg(theme.inactive)
     };
 
     frame.render_widget(
@@ -222,30 +255,30 @@ fn render_preview(frame: &mut Frame, app: &App, area: Rect) {
                     .title(" Message ")
                     .border_style(border_style),
             )
-            .style(Style::default().fg(Color::Gray)),
+            .style(Style::default().fg(theme.preview_text)),
         area,
     );
 }
 
-fn render_status(frame: &mut Frame, app: &App, area: Rect) {
+fn render_status(frame: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     let status = app.status();
     let (msg, style): (&str, Style) = if app.editing_title().is_some() {
         (
             " [Enter] Confirm title  [Esc] Cancel",
-            Style::default().fg(Color::Rgb(250, 189, 47)),
+            Style::default().fg(theme.active),
         )
     } else if !status.is_empty() {
-        (status, Style::default().fg(Color::Yellow))
+        (status, Style::default().fg(theme.status_msg))
     } else {
         (
             " [↑↓/jk] Navigate  [Tab] Switch pane  [Enter] Resume  [e] Edit title  [y] Copy  [d] Delete  [q] Quit",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.hint),
         )
     };
     frame.render_widget(Paragraph::new(Span::styled(msg, style)), area);
 }
 
-fn render_confirm(frame: &mut Frame, area: Rect) {
+fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme) {
     let popup = centered_rect(44, 6, area);
     frame.render_widget(Clear, popup);
     frame.render_widget(
@@ -254,7 +287,7 @@ fn render_confirm(frame: &mut Frame, area: Rect) {
             Line::from(Span::styled(
                 "  Delete this session? This cannot be undone.",
                 Style::default()
-                    .fg(Color::Red)
+                    .fg(theme.danger)
                     .add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
@@ -266,7 +299,7 @@ fn render_confirm(frame: &mut Frame, area: Rect) {
         .block(
             Block::bordered()
                 .title(" Confirm Delete ")
-                .border_style(Style::default().fg(Color::Red)),
+                .border_style(Style::default().fg(theme.danger)),
         ),
         popup,
     );


### PR DESCRIPTION
## Summary

- Introduces a `Theme` struct in `ui.rs` with 7 named color fields (`active`, `inactive`, `meta`, `preview_text`, `status_msg`, `hint`, `danger`)
- Built-in themes: `gruvbox-dark` (default), `catppuccin-mocha`, `catppuccin-macchiato`, `catppuccin-frappe`, `catppuccin-latte`
- `--theme <name>` CLI flag to select a theme at launch
- `~/.config/ccm/config.toml` config file for setting a default theme and/or overriding individual colors
- Precedence: `--theme` flag > config `theme` > `[colors]` overrides > `gruvbox-dark`
- README updated with usage, theme list, and config file format

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `cargo run` — confirm default Gruvbox colors unchanged
- [x] `cargo run -- --theme catppuccin-mocha` — confirm Catppuccin Mocha colors
- [x] Create `~/.config/ccm/config.toml` with `theme = "catppuccin-latte"` and confirm it loads
- [x] Add a `[colors]` override and confirm it applies on top of the selected theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)