### PR TITLE
Add Homebrew formula draft and package metadata

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,11 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "ccm"
 version = "0.1.0"
 edition = "2024"
+description = "Terminal UI for browsing, managing, and resuming Claude Code sessions"
+license = "MIT"
+repository = "https://github.com/sanjayginde/claude-code-manager"
+homepage = "https://github.com/sanjayginde/claude-code-manager"
+readme = "README.md"
+keywords = ["claude", "cli", "tui", "ratatui", "anthropic"]
+categories = ["command-line-utilities"]
 
 [[bin]]
 name = "ccm"

--- a/packaging/homebrew/ccm.rb
+++ b/packaging/homebrew/ccm.rb
@@ -1,0 +1,49 @@
+# Homebrew formula for ccm (Claude Code Manager).
+#
+# To publish via a personal tap:
+#   1. Create a repo named `homebrew-tap` under your GitHub account
+#      (e.g. github.com/sanjayginde/homebrew-tap).
+#   2. Cut a release tag (e.g. `v0.1.0`) on this repo so a source tarball
+#      is available at the `url` below.
+#   3. Compute the tarball sha256:
+#        curl -L https://github.com/sanjayginde/claude-code-manager/archive/refs/tags/v0.1.0.tar.gz | shasum -a 256
+#   4. Copy this file to `Formula/ccm.rb` in the tap repo and replace the
+#      sha256 placeholder with the real value.
+#   5. Users install with:
+#        brew install sanjayginde/tap/ccm
+#
+# Updating for a new release: bump `url` to the new tag, update `sha256`,
+# and push to the tap. `brew bump-formula-pr` can automate this.
+class Ccm < Formula
+  desc "Terminal UI for browsing, managing, and resuming Claude Code sessions"
+  homepage "https://github.com/sanjayginde/claude-code-manager"
+  url "https://github.com/sanjayginde/claude-code-manager/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "REPLACE_WITH_RELEASE_TARBALL_SHA256"
+  license "MIT"
+  head "https://github.com/sanjayginde/claude-code-manager.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  def caveats
+    <<~EOS
+      ccm resumes sessions by exec'ing `claude --resume <uuid>`, so it
+      requires the Claude Code CLI to be installed and on your PATH:
+        https://docs.claude.com/en/docs/claude-code
+
+      To enable AI-generated session titles (optional), set:
+        export ANTHROPIC_API_KEY=...
+      Without the key, ccm falls back to showing a truncated first message.
+    EOS
+  end
+
+  test do
+    # `ccm` is a TUI with no --help/--version flags today; just assert the
+    # binary is executable and present.
+    assert_predicate bin/"ccm", :exist?
+    assert_predicate bin/"ccm", :executable?
+  end
+end


### PR DESCRIPTION
Preps the project for Homebrew distribution via a personal tap.

## Changes

- **`Cargo.toml`**: add `license`, `description`, `repository`, `homepage`, `readme`, `keywords`, and `categories` so the crate has the metadata Homebrew (and crates.io, if we ever publish there) expects.
- **`.github/workflows/rust.yml`**: add `macos-14` (arm64) to the CI matrix alongside `ubuntu-latest` so we catch macOS-specific breakage before cutting releases. `fail-fast: false` so a flake on one OS doesn't mask the other.
- **`packaging/homebrew/ccm.rb`**: draft Homebrew formula ready to copy into a `sanjayginde/homebrew-tap` repo. Uses `depends_on "rust" => :build` and `std_cargo_args` so Homebrew provides the toolchain. `caveats` documents the runtime `claude` CLI dependency and the optional `ANTHROPIC_API_KEY`.

## Still to do after merge (not in this PR)

1. Tag `v0.1.0` + cut a GitHub release.
2. Compute the release tarball sha256 and substitute it into `ccm.rb`.
3. Create the `homebrew-tap` repo and copy the formula to `Formula/ccm.rb`.
4. Smoke test: `brew install sanjayginde/tap/ccm`.

## Verification

`cargo build` passes locally. The formula's `test` block just asserts the binary exists and is executable, because `ccm` doesn't yet expose `--help` or `--version` (confirmed by grep of `main.rs`). Worth strengthening later if those flags are added.