### PR TITLE
Bump rustls-webpki and rand to patched versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1767,7 +1767,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1816,18 +1816,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2139,9 +2139,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Closes three open low-severity Dependabot alerts by bumping the transitive pins in `Cargo.lock`. No `Cargo.toml` changes are needed — both are already in semver-compatible ranges, just stale in the lockfile.

## Alerts addressed

| Alert | Package | From | To | Summary |
|---|---|---|---|---|
| #3 | rustls-webpki | 0.103.10 | 0.103.13 | Name constraints for URI names were incorrectly accepted |
| #4 | rustls-webpki | 0.103.10 | 0.103.13 | Name constraints accepted for certs asserting a wildcard name |
| #2 | rand (0.9.x) | 0.9.2 | 0.9.4 | Unsound with a custom logger using `rand::rng()` |
| #2 | rand (0.8.x) | 0.8.5 | 0.8.6 | Same advisory; 0.8.6 is the upstream backport |

(The alert numbers above reference https://github.com/sanjayginde/claude-code-manager/security/dependabot, not PR/issue numbers.)

## Why two `rand` lines

Advisory #2's vulnerable range is `>= 0.7.0, < 0.9.3`, which covers **both** major lines present in our lockfile:
- `rand 0.9.2` (pulled in by `quinn-proto` via `reqwest`'s HTTP/3 support)
- `rand 0.8.5` (pulled in by `phf_generator`)

An earlier revision of this PR only patched the 0.9.x line. The 0.8.x bump was pulled in after realizing Dependabot's own PR (#41) correctly flagged it.

## Supersedes #41

This PR now covers everything in the Dependabot-generated #41 plus the additional 0.9.x bump it missed. #41 should be closed.

## How the updates propagate

- `rustls-webpki` → via `reqwest` → `rustls`. Used at TLS handshake for the Anthropic API call.
- `rand 0.9.x` → via `quinn-proto` → `reqwest` HTTP/3.
- `rand 0.8.x` → via `phf_generator` → static perfect-hash-map gen, build-time-adjacent.

Neither crate is used directly from `ccm`'s own code.

## Verification

Locally on macOS 14 / Rust 1.91.1:

- `cargo build`: clean
- `cargo test`: 56 passed
- `cargo clippy -- -D warnings`: clean

Branch has been rebased on the post-#43 `main` so CI should go green.