### PR TITLE
Fix clippy::unnecessary_sort_by for session ordering

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -201,7 +201,7 @@ fn load_sessions(dir: &Path) -> anyhow::Result<Vec<Session>> {
         });
     }
 
-    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.last_modified));
     Ok(sessions)
 }
 


### PR DESCRIPTION
Rust 1.95's clippy introduced `clippy::unnecessary_sort_by`, which trips on `sort_by` closures that could be `sort_by_key`. Our CI runs with `-D warnings`, so this was breaking the build on both open PRs (#40, #42) as well as locally on 1.95.

## Change

```rust
// before
sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
// after
sessions.sort_by_key(|s| std::cmp::Reverse(s.last_modified));
```

Semantically identical -- descending by `last_modified`. The other `sort_by` in the file (`projects.sort_by` at L131) is not flagged because its closure does real work (chained `Option` handling to pull `last_modified` off the first session).

## Verification

- `cargo clippy -- -D warnings`: clean
- `cargo test`: 56 passed

## Suggested merge order

1. This PR (fastest, unblocks CI everywhere)
2. PR #42 (security-only `Cargo.lock` bump)
3. PR #40 (Homebrew + macOS CI)

Branches #40 and #42 will rebase cleanly once this lands.