### PR TITLE
feat: add n keybinding to start a new session from CCM

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -42,6 +42,7 @@ pub enum Action {
     ConfirmDelete,
     CancelDelete,
     Resume,
+    NewSession,
     Quit,
     CopyMessage,
     TitleUpdate { uuid: String, title: String },
@@ -64,6 +65,7 @@ struct EditBuffer {
 pub enum Response {
     Continue,
     ResumeSession { cwd: PathBuf, uuid: String },
+    NewSession { cwd: PathBuf },
     Quit,
 }
 
@@ -80,10 +82,12 @@ pub struct App {
     editing_title: Option<EditBuffer>,
     status: String,
     store: DynStore,
+    startup_cwd: Option<PathBuf>,
 }
 
 impl App {
     pub fn new(projects: Vec<Project>, store: DynStore, cwd: Option<PathBuf>) -> Self {
+        let startup_cwd = cwd.clone();
         let initial_project = cwd
             .and_then(|cwd| {
                 projects.iter().position(|p| {
@@ -102,6 +106,7 @@ impl App {
             editing_title: None,
             status: String::new(),
             store,
+            startup_cwd,
         }
     }
 
@@ -151,6 +156,10 @@ impl App {
                     self.active_pane = Pane::Sessions;
                 }
                 Ok(Response::Continue)
+            }
+            Action::NewSession => {
+                let cwd = self.startup_cwd.clone().unwrap_or_default();
+                Ok(Response::NewSession { cwd })
             }
             Action::CopyMessage => {
                 match self.current_session().and_then(|s| s.first_message.as_deref()) {
@@ -826,5 +835,22 @@ mod tests {
         app.dispatch(Action::StartEditTitle).unwrap();
         assert_eq!(app.editing_title(), Some("Existing"));
         assert_eq!(app.editing_title_cursor(), "Existing".len());
+    }
+
+    // ── new session ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_session_returns_startup_cwd() {
+        let cwd = PathBuf::from("/tmp/test-project");
+        let mut app = App::new(vec![], Arc::new(NullSessionStore), Some(cwd.clone()));
+        let resp = app.dispatch(Action::NewSession).unwrap();
+        assert!(matches!(resp, Response::NewSession { cwd: c } if c == cwd));
+    }
+
+    #[test]
+    fn new_session_returns_empty_path_when_no_cwd() {
+        let mut app = make_app(&[1]);
+        let resp = app.dispatch(Action::NewSession).unwrap();
+        assert!(matches!(resp, Response::NewSession { cwd: c } if c == PathBuf::default()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 enum Outcome {
     Quit,
     Resume { cwd: PathBuf, uuid: String },
+    NewSession { cwd: PathBuf },
 }
 
 #[tokio::main]
@@ -68,6 +69,25 @@ async fn main() -> anyhow::Result<()> {
             let status = std::process::Command::new("claude")
                 .args(["--resume", &uuid])
                 .status()?;
+            std::process::exit(status.code().unwrap_or(0));
+        }
+    }
+
+    if let Outcome::NewSession { cwd } = outcome {
+        if cwd.exists() {
+            std::env::set_current_dir(&cwd)?;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            let err = std::process::Command::new("claude").exec();
+            return Err(anyhow::anyhow!("failed to exec claude: {}", err));
+        }
+
+        #[cfg(not(unix))]
+        {
+            let status = std::process::Command::new("claude").status()?;
             std::process::exit(status.code().unwrap_or(0));
         }
     }
@@ -168,6 +188,7 @@ where
                 | KeyCode::Char('h')
                 | KeyCode::Char('l') => Action::SwitchPane,
                 KeyCode::Enter => Action::Resume,
+                KeyCode::Char('n') => Action::NewSession,
                 KeyCode::Char('d') => Action::RequestDelete,
                 KeyCode::Char('e') => Action::StartEditTitle,
                 KeyCode::Char('y') => Action::CopyMessage,
@@ -179,6 +200,7 @@ where
             Response::Continue => {}
             Response::Quit => return Ok(Outcome::Quit),
             Response::ResumeSession { cwd, uuid } => return Ok(Outcome::Resume { cwd, uuid }),
+            Response::NewSession { cwd } => return Ok(Outcome::NewSession { cwd }),
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -370,7 +370,7 @@ fn render_status(frame: &mut Frame, app: &App, area: Rect, theme: &Theme) {
         (status, Style::default().fg(theme.status_msg))
     } else {
         (
-            " [↑↓/jk] Navigate  [Tab] Switch pane  [Enter] Resume  [e] Edit title  [y] Copy  [d] Delete  [q] Quit",
+            " [↑↓/jk] Navigate  [Tab] Switch pane  [Enter] Resume  [n] New  [e] Edit title  [y] Copy  [d] Delete  [q] Quit",
             Style::default().fg(theme.hint),
         )
     };


### PR DESCRIPTION
## Summary

- Adds `n` keybinding in normal mode to launch `claude` in the directory where CCM was started
- Stores the startup CWD on `App` so `dispatch` can return it via the new `Response::NewSession` variant
- Mirrors the existing resume flow: sets cwd, then `exec`s `claude` (Unix) or spawns+waits (non-Unix)
- Updates the help bar hint text to include `[n] New`

## Test plan

- [x] `cargo clippy -- -D warnings` passes clean
- [x] `cargo test` passes (2 new tests: `new_session_returns_startup_cwd`, `new_session_returns_empty_path_when_no_cwd`)
- [x] Manual: run `ccm` from a project directory, press `n`, verify `claude` starts in that directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)